### PR TITLE
requiring 'cgi'

### DIFF
--- a/lib/cheddargetter_client_ruby.rb
+++ b/lib/cheddargetter_client_ruby.rb
@@ -1,5 +1,5 @@
 require 'httparty'
-require 'CGI' unless Object.const_defined?("CGI")
+require 'cgi' unless Object.const_defined?("CGI")
 
 module CheddarGetter
   autoload :Client, "cheddar_getter/client"


### PR DESCRIPTION
action_pack isn't used in our JRuby integration app so 'cgi' is not included and CGI is not defined.  Looks like CGI has always been defined for your testing.

forked to do some testing with JRuby/Rails 3 would like to not have it forked forever.
