### PR TITLE
Fix duplicated httparty dependency in gemspec

### DIFF
--- a/cheddargetter_client_ruby.gemspec
+++ b/cheddargetter_client_ruby.gemspec
@@ -58,7 +58,6 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<jeweler>, ["~> 1.5.1"])
       s.add_development_dependency(%q<rcov>, [">= 0"])
       s.add_development_dependency(%q<ruby-debug>, [">= 0"])
-      s.add_runtime_dependency(%q<httparty>, [">= 0.4.3"])
     else
       s.add_dependency(%q<httparty>, [">= 0.4.3"])
       s.add_dependency(%q<shoulda>, [">= 0"])
@@ -66,7 +65,6 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<jeweler>, ["~> 1.5.1"])
       s.add_dependency(%q<rcov>, [">= 0"])
       s.add_dependency(%q<ruby-debug>, [">= 0"])
-      s.add_dependency(%q<httparty>, [">= 0.4.3"])
     end
   else
     s.add_dependency(%q<httparty>, [">= 0.4.3"])
@@ -75,7 +73,5 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<jeweler>, ["~> 1.5.1"])
     s.add_dependency(%q<rcov>, [">= 0"])
     s.add_dependency(%q<ruby-debug>, [">= 0"])
-    s.add_dependency(%q<httparty>, [">= 0.4.3"])
   end
 end
-


### PR DESCRIPTION
Bundler > 1.10.0 would not install gem due to validation failure. Addresses #10
